### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Photos.json
+++ b/org.gnome.Photos.json
@@ -30,8 +30,6 @@
         "--talk-name=org.gtk.vfs.*"
     ],
     "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
         "env": {
             "V": "1"
         }


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.