### PR TITLE
Update to GNOME 47

### DIFF
--- a/org.gnome.Photos.json
+++ b/org.gnome.Photos.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnome.Photos",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-photos",
     "finish-args": [
@@ -215,8 +215,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gimp.org/pub/gegl/0.4/gegl-0.4.48.tar.xz",
-                    "sha256": "418c26d94be8805d7d98f6de0c6825ca26bd74fcacb6c188da47533d9ee28247"
+                    "url": "https://download.gimp.org/pub/gegl/0.4/gegl-0.4.54.tar.xz",
+                    "sha256": "35a342f08c6b4379adee2cb5748fc4e307cfdcf2417c0bb17d6ca6543f238b1e"
                 }
             ]
         },
@@ -286,7 +286,7 @@
         },
         "shared-modules/intltool/intltool-0.51.json",
         {
-            "name": "tracker-miners",
+            "name": "localsearch",
             "buildsystem": "meson",
             "config-opts": [
                 "-Ddomain_prefix=org.gnome.Photos",
@@ -300,8 +300,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/tracker-miners/3.7/tracker-miners-3.7.0.tar.xz",
-                    "sha256": "74e796c1625094a8a2175993c7907281e97ab6e002578e846b8f4ca44e36bf61",
+                    "url": "https://download.gnome.org/sources/localsearch/3.8/localsearch-3.8.2.tar.xz",
+                    "sha256": "cda69195f6845357a8d91c023670efe92238f4d138a1ef7a1401f45a2a8403ce",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "tracker-miners",


### PR DESCRIPTION
tracker-miner is gone. Vive localsearch
Update gegl due to ftbs